### PR TITLE
pkg/dos/ to automate the build with OpenWatcom under doxbox

### DIFF
--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - moraes/pr_dos_win
 jobs:
   for-hosted:
     strategy:

--- a/Makefile.wat
+++ b/Makefile.wat
@@ -183,9 +183,6 @@ keys.c:	setmaps.exe keys.txt
 # Note: it may be necessary to manually copy the source file from
 # the distribution CDROM to the installation.  On the CDROM, the
 # file's path is \watcom\src\startup\wildargv.c.
-# Or you can get it from 
-# http://perforce.openwatcom.org:4000/@md=d&cd=//depot/openwatcom/bld/clib/startup/c/&c=WFs@//depot/openwatcom/bld/clib/startup/c/wildargv.c?ac=22
-# (e.g. version 3 seems to compile with OpenWatcom 1.9)
 # The latest versions at github need newer compilers than 1.9.0
 # https://github.com/open-watcom/open-watcom-v2/master/bld/clib/startup/c/wildargv.c
 # At least with some versions (fixed in the github version), wildargv.c does not accept tabs as
@@ -199,8 +196,8 @@ keys.c:	setmaps.exe keys.txt
 # to:
 #		    if( *p == ' ' || *p == '\t' ) break;
 
-#WILDSRC=$(%WATCOM)\src\startup\wildargv.c
-WILDSRC=wildargv.c
+WILDSRC=$(%WATCOM)\src\startup\wildargv.c
+
 wildargv.obj:	$(WILDSRC)
 	$(CC) $(CFLAGS) $(WILDSRC)
 

--- a/README
+++ b/README
@@ -5,10 +5,15 @@
 # this notice is included in all the source files and documentation.     #
 ##########################################################################
 
-[Updated in 2023 Nov]
+[Updated in 2026 Jul]
 
 JOVE on UNIX/Linux/MacOS X/*BSD/CygWin Systems
 ----------------------------------------------
+
+JOVE is Jonathan's Own Version of Emacs.  It is an interactive
+screen-oriented text editor that was meant to be compatible with EMACS,
+but is also very small, fast and efficient.  It is written in C, and
+designed for use by C programmers.
 
 Getting JOVE
 ------------
@@ -40,12 +45,16 @@ over and use
 Ensure you have the tools required to build Jove.  You need a C compiler
 (classic Unix cc, gcc or clang should work), the make utility, 
 and basic headers for libc, which may require extra packages on
-some Linux distributions.
+some Linux distributions.  groff is needed to format printed documentation,
+though pre-formatted versions are often included in pre-packaged distributions.
+ctags of some form is needed to generate tags file for Jove's find-tag commands.
+
     Debian, Ubuntu, Mint: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends gcc make ncurses-dev pkg-config exuberant-ctags
+    Fedora, Red Hat and derivatives: yum install make gcc ncurses-devel groff-base ctags
     Alpine: apk update && apk add gcc make musl-dev ncurses-dev pkgconfig ctags
     MacOSX/Darwin: brew install make ncurses 
     Nix: nix-shell -p gnumake 
-    Arch: pacman -Sy gcc make # pkgconf ncurses
+    Arch: pacman -Sy gcc make pkgconf ncurses groff ctags
     Gentoo: # comes with gcc and make and headers by default!
 
 For many modern systems (Linux, various BSDs, MacOSX/Darwin,

--- a/README.dos
+++ b/README.dos
@@ -15,21 +15,23 @@ allows you to easily understand and modify JOVE.  The executable
 version allows you to easily install JOVE without using a C compiler.
 Neither requires the other.
 
-Each distribution may be in the form of a .zip archive (smaller) or
-a .sfx archive (self-extracting executable zip, larger, may be disallowed
-by various security tools, though that may also be true for .zip). You can
-create a suitable archive (source on Un*x, executable on DOS/Windows) using
-	make zip
-if you have a zip command installed.  If you use pkunzip to unpack,
+Each distribution may be in the form of a .zip archive, so you will need
+a command like unzip, pkunzip, 7-zip or other un-archiver that supports
+the zip format.  Note that some firewalls or endpoint protection software
+may not allow downloads of .zip files. If you use pkunzip to unpack,
 be sure to use the -d flag to get it to correctly place files
-in subdirectories.  If you need/prefer to use 7-zip, something like
+in subdirectories. 
+
+A source archive in .zip form can be generated on Posix using
+	make zip
+if you have a zip command installed. If you use 7-zip, something like
 	make ZIP=7z ZIPOPTS=a zip ZIPEXT=7z
 should work (though 7z does not make filenames DOS-friendly 8.3,
 probably does not matter for modern Windows machines)
 
 The source distribution for MSDOS (and WIN32 -- Windows/95 or later)
 is an archive called joveNNNs.zip, where NNN is a version
-number (for example, jove417s.zip for 4.17).  The source archive
+number (for example, jove500s.zip for 5.0).  The source archive
 contains all the source files needed to compile JOVE on an MSDOS or
 WIN32 machine.  It differs in three ways from the generic JOVE source
 distribution.  First, it is distributed in a conventional MSDOS
@@ -38,8 +40,7 @@ because they are of no use under MSDOS (for example, the X Window
 System support) and may not fit the 8.3 naming straitjacket.  Third, a
 few files are pre-built on UNIX and included because the tools to
 build them are not generally available under MSDOS (for example, the
-formatted documentation).  The source distribution for MSDOS can be
-built from the generic distribution on UNIX with the command "make zip".
+formatted documentation).
 
 The executable distribution for MSDOS on the IBM PC is an archive called
 joveNNNd.zip where NNN is a version number (e.g. 417 for 4.17).  The

--- a/jmake.sh
+++ b/jmake.sh
@@ -36,7 +36,7 @@ case "$u" in
 	*x86_64*)	optflags="$optflags -Wno-long-long" # Win64 needs long long, and older gcc produce a C90 complaint;;
 	esac
 	extra="LOCALCC=$locc XEXT=.exe WINDRES=$u-windres EXTRAOBJS=win32.o ICON=jjove.coff"
-	ldlibs=-lcomdlg32
+	ldlibs="-static -static-libgcc -lcomdlg32 -lssp_nonshared"
 	;;
 *-linux-musl*) # presumably set via something like JMAKE_UNAME=i486-linux-musl
 	: ${JMAKE_RELATIVE=1}

--- a/pkg/dos/README
+++ b/pkg/dos/README
@@ -1,0 +1,30 @@
+To cross-compile a DOS version of Jove on Linux, use the
+dosbox emulator from https://www.dosbox.com/
+or, on a Debian-derived machine:
+	apt install dosbox
+
+running pkg/dos/testdos.sh should create a tmp dir, download
+openwatcom (or use a previously downloaded one from
+$HOME/.cache) and build jove with it.
+
+In the Dosbox, the usual tests run are something like
+	cd ..		# goes up from C:\JOVE500D to C:\
+	JOVE500D\JOVE.EXE	# should startup with the little help window
+
+Inside jove, I run a few commands 
+
+M-x teach-jove, and some moving/editing,
+
+M-x describe-command to ensure it finds help correctly,
+
+^X ! dir to see it runs a command properly
+
+^X ^C to exit
+
+Then test wildcard with
+	JOVE500D\JOVE.EXE JOVE500S\*.C
+and do a bit of browsing around.
+
+Then use 
+	exit
+to get out of dosbox, it makes a zip of the binary dir in jove500d.zip

--- a/pkg/dos/dosbox.conf
+++ b/pkg/dos/dosbox.conf
@@ -1,0 +1,14 @@
+[autoexec]
+@echo off
+mount c: .
+c:
+path c:\watcom\binw;%path%
+set include=c:\watcom\h
+set watcom=c:\watcom
+set edpath=c:\watcom\eddat
+set wipfc=c:\watcom\wipfc
+if not exist "c:\tmp\nul" mkdir c:\tmp
+call build
+
+[cpu]
+cycles=max

--- a/pkg/dos/testdos.sh
+++ b/pkg/dos/testdos.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Prereq: dosbox unzip zip
+: ${WATFTP=https://openwatcom.org/ftp/install}
+: ${WATZIP=open-watcom-c-dos-1.9.exe}
+: ${HOMECACHE=$HOME/.cache}
+set -eux
+d=$(dirname $0)
+if test ! -f "$d/dosbox.conf"; then
+	echo "$0: cannot find dosbox.conf in \"$d\"" >&2
+	exit 1
+fi
+if test ! -f "$d/../../Makefile"; then
+	echo "$0: cannot find ../../Makefile from \"$d\"" >&2
+	exit 2
+fi
+td=$(mktemp -d)
+cp "$d/dosbox.conf" "$td"/
+cd "$d"/../..
+jd=$(pwd)
+make zip
+if test ! -f .version; then
+	echo "$0: cannot find .version in \"$jd\"" >&2
+	exit 3
+fi
+ver=$(sed 's,\.,,g' .version)
+jsrc=jove${ver}s.zip
+if test ! -f "$jsrc"; then
+	echo "$0: cannot find $jsrc in \"$jd\"" >&2
+	exit 3
+fi
+wzip="$HOMECACHE/$WATZIP"
+if test ! -d $HOMECACHE; then
+	mkdir $HOMECACHE
+fi
+if test ! -f "$wzip"; then
+	wget -o "$wzip"  "$WATFTP/$WATZIP"
+fi
+cp "$jsrc" "$td"/
+cd "$td"
+unzip "$jsrc"
+mkdir watcom tmp "jove${ver}d"
+cd watcom
+unzip "$wzip"
+cd ..
+cat << EOF > build.bat
+cd jove${ver}s
+wmake /f makefile.wat
+copy jjove.exe ..\jove${ver}d\jove.exe
+copy recover.exe readme readme.dos ..\jove${ver}d
+md ..\jove${ver}d\doc
+copy doc\*.* ..\jove${ver}d\doc
+EOF
+echo "Starting dosbox in $td"
+dosbox .
+if test ! -d "$jd/DIST"; then mkdir "$jd/DIST"; fi
+zip -r -q -k "$jd/DIST/jove500d.zip" jove500d
+echo "If everything worked, please"
+echo "    rm -rf $td"

--- a/testbuild.sh
+++ b/testbuild.sh
@@ -62,6 +62,9 @@ case $# in
 		case "$TB_MACH" in
 		x86_64) $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --force-yes mingw-w64;;
 		esac
+		case "$dist" in
+		DIST/Linux-x86_64-ubuntu-20.04-*) $SUDO env DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --force-yes curl gnupg pbuilder;;
+		esac
 		# similar OPTFLAGS to what Cord uses for debian packaging
 		TB_OPTFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2"
 	elif type apk 2> /dev/null; then

--- a/tune.h
+++ b/tune.h
@@ -71,6 +71,6 @@
 # undef PTYPROCS	/* defined only if IPROCS is */
 #endif
 
-#ifndef MSDOS
+#ifndef DFLT_MODE
 # define DFLT_MODE	0666	/* file will be created with this mode */
 #endif

--- a/tune.txt
+++ b/tune.txt
@@ -17,6 +17,10 @@ BACKUPFILES	This enables backing up files on write.  I guess lots of
 
 CMT_FMT		This enables code to format and indent C comments.
 
+DFLT_MODE	Initial value for file-creation-mode, set to 0666
+		(since it will be modified by the user umask
+		setting, which is what really matters)
+
 F_COMPLETION	Enables filename completion.  This requires that your
 		system have reasonable directory scanning capabilities.
 		It's a really handy feature, so it's worth turning on.


### PR DESCRIPTION
tune.h fix so this compiles with OpenWatcom/dosbox again tweak to testbuild so mingw crosscompiles for Windows work (linker needs -lssp_nonshared)
testbuild installs and runs pbuilder if ubuntu-20 so it generates arm*,x86* deb packages (using bookworm image now that buster is retired; seems best to use an old image so libc symbols have a good chance of working across many distro revs?)